### PR TITLE
Fix underrun problem on baytrailaudio.

### DIFF
--- a/hdmi_audio_20150319.patch
+++ b/hdmi_audio_20150319.patch
@@ -8249,7 +8249,7 @@ index 374f964..5385e0f 100644
  #define POSTING_READ16(reg)	(void)I915_READ16_NOTRACE(reg)
  
 diff --git a/drivers/gpu/drm/i915/i915_irq.c b/drivers/gpu/drm/i915/i915_irq.c
-index c05c84f..e8ee857 100644
+index c05c84f..9ed3e35 100644
 --- a/drivers/gpu/drm/i915/i915_irq.c
 +++ b/drivers/gpu/drm/i915/i915_irq.c
 @@ -688,6 +688,29 @@ i915_disable_pipestat(struct drm_i915_private *dev_priv, enum pipe pipe,
@@ -8315,7 +8315,7 @@ index c05c84f..e8ee857 100644
  	if (pipe_stats[0] & PIPE_GMBUS_INTERRUPT_STATUS)
  		gmbus_irq_handler(dev);
  }
-@@ -2666,6 +2708,25 @@ static int valleyview_enable_vblank(struct drm_device *dev, int pipe)
+@@ -2666,6 +2708,28 @@ static int valleyview_enable_vblank(struct drm_device *dev, int pipe)
  	return 0;
  }
  
@@ -8328,11 +8328,14 @@ index c05c84f..e8ee857 100644
 +	int pipe = 1;
 +
 +	spin_lock_irqsave(&dev_priv->irq_lock, irqflags);
++	i915_enable_lpe_pipestat(dev_priv, pipe);
++
 +	imr = I915_READ(VLV_IMR);
 +	/* Audio is on Stream A */
 +	imr &= ~I915_LPE_PIPE_A_INTERRUPT;
 +	I915_WRITE(VLV_IMR, imr);
-+	i915_enable_lpe_pipestat(dev_priv, pipe);
++	I915_WRITE(VLV_IER, ~imr);
++	POSTING_READ(VLV_IER);
 +	spin_unlock_irqrestore(&dev_priv->irq_lock, irqflags);
 +
 +	return 0;
@@ -8341,7 +8344,7 @@ index c05c84f..e8ee857 100644
  static int gen8_enable_vblank(struct drm_device *dev, int pipe)
  {
  	struct drm_i915_private *dev_priv = dev->dev_private;
-@@ -2697,6 +2758,24 @@ static void i915_disable_vblank(struct drm_device *dev, int pipe)
+@@ -2697,6 +2761,27 @@ static void i915_disable_vblank(struct drm_device *dev, int pipe)
  	spin_unlock_irqrestore(&dev_priv->irq_lock, irqflags);
  }
  
@@ -8356,7 +8359,10 @@ index c05c84f..e8ee857 100644
 +	spin_lock_irqsave(&dev_priv->irq_lock, irqflags);
 +	imr = I915_READ(VLV_IMR);
 +	imr |= I915_LPE_PIPE_A_INTERRUPT;
++	I915_WRITE(VLV_IER, ~imr);
 +	I915_WRITE(VLV_IMR, imr);
++	POSTING_READ(VLV_IMR);
++
 +	i915_disable_lpe_pipestat(dev_priv, pipe);
 +	spin_unlock_irqrestore(&dev_priv->irq_lock, irqflags);
 +

--- a/hdmi_audio_20150319.patch
+++ b/hdmi_audio_20150319.patch
@@ -9317,10 +9317,10 @@ index 0000000..b28eb3b
 +obj-m += $(DRIVER_NAME).o
 diff --git a/sound/hdmi_audio/intel_mid_hdmi_audio.c b/sound/hdmi_audio/intel_mid_hdmi_audio.c
 new file mode 100644
-index 0000000..cfe3b06
+index 0000000..f45c334
 --- /dev/null
 +++ b/sound/hdmi_audio/intel_mid_hdmi_audio.c
-@@ -0,0 +1,2020 @@
+@@ -0,0 +1,2019 @@
 +/*
 + *   intel_mid_hdmi_audio.c - Intel HDMI audio driver for MID
 + *
@@ -10451,7 +10451,6 @@ index 0000000..cfe3b06
 +		pr_debug("HDMI status =0x%x\n", hdmi_status);
 +		if (hdmi_status & AUD_CONFIG_MASK_UNDERRUN) {
 +			i++;
-+			hdmi_status &= ~AUD_CONFIG_MASK_UNDERRUN;
 +			had_write_register(AUD_HDMI_STATUS_v2, hdmi_status);
 +		} else
 +			break;


### PR DESCRIPTION
I was suffering from XRUN problem on my baytrail device. It's mainly due to lack of configuration of LPE audio interrupt. Can you merge this one? Another guy also hit the same problem. (And probably there might be more.) Please take a look at the following thread in alsa-devel list.
http://mailman.alsa-project.org/pipermail/alsa-devel/2016-February/104834.html
